### PR TITLE
Support appcenter distribute and fix Android context issue

### DIFF
--- a/demo-ng/app/app.module.ts
+++ b/demo-ng/app/app.module.ts
@@ -4,7 +4,7 @@ import { NativeScriptModule } from "nativescript-angular/nativescript.module";
 import { AppRoutingModule } from "./app-routing.module";
 import { AppComponent } from "./app.component";
 
-import { AppCenter, AppCenterAnalytics, AppCenterCrashes } from "nativescript-microsoft-appcenter";
+import {AppCenter, AppCenterAnalytics, AppCenterCrashes, AppCenterDistribute} from "nativescript-microsoft-appcenter";
 
 @NgModule({
     bootstrap: [
@@ -23,7 +23,8 @@ import { AppCenter, AppCenterAnalytics, AppCenterCrashes } from "nativescript-mi
     providers: [
         AppCenter, 
         AppCenterAnalytics, 
-        AppCenterCrashes
+        AppCenterCrashes,
+        AppCenterDistribute
     ]
 })
 export class AppModule { }

--- a/demo-ng/app/home/home.component.html
+++ b/demo-ng/app/home/home.component.html
@@ -12,5 +12,7 @@
     <Label row="6" [text]="analyticsIsEnabled" class="t-20 text-center c-black" textWrap="true"></Label>
     <Label row="7" text="Crashes Status" class="t-20 text-center c-black" textWrap="true"></Label>
     <Label row="8" [text]="crashesIsEnabled" class="t-20 text-center c-black" textWrap="true"></Label>
-    <Button row="9" text="Crashes Test" (tap)="crashesTap()"></Button>
+    <Label row="9" text="Distribute Status" class="t-20 text-center c-black" textWrap="true"></Label>
+    <Label row="10" [text]="distributeIsEnabled" class="t-20 text-center c-black" textWrap="true"></Label>
+    <Button row="11" text="Crashes Test" (tap)="crashesTap()"></Button>
 </StackLayout>

--- a/demo-ng/app/home/home.component.ts
+++ b/demo-ng/app/home/home.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from "@angular/core";
-import { AppCenter, AppCenterAnalytics, AppCenterCrashes } from "nativescript-microsoft-appcenter";
+import {AppCenter, AppCenterAnalytics, AppCenterCrashes, AppCenterDistribute} from "nativescript-microsoft-appcenter";
 
 @Component({
     selector: "Home",
@@ -11,11 +11,13 @@ export class HomeComponent implements OnInit {
     public appCenterIsEnabled: string;
     public analyticsIsEnabled: string;
     public crashesIsEnabled: string;
+    public distributeIsEnabled: string;
 
     constructor(
         private appCenter: AppCenter,
         private analytics: AppCenterAnalytics,
-        private crashes: AppCenterCrashes) {
+        private crashes: AppCenterCrashes,
+        private distribute: AppCenterDistribute) {
     }
 
     ngOnInit(): void {
@@ -23,6 +25,7 @@ export class HomeComponent implements OnInit {
         this.appCenterIsEnabled = this.appCenter.isEnabled() ? "Enabled" : "Disabled";
         this.analyticsIsEnabled = this.analytics.isEnabled() ? "Enabled" : "Disabled";
         this.crashesIsEnabled = this.crashes.isEnabled() ? "Enabled" : "Disabled";
+        this.distributeIsEnabled = this.distribute.isEnabled() ? "Enabled" : "Disabled";
         this.analytics.trackEvent("Testing...");
     }
 

--- a/demo-ng/app/main.ts
+++ b/demo-ng/app/main.ts
@@ -8,7 +8,8 @@ if (application.ios){
     let appCenterSettings: AppCenterSettings = {
         appSecret: "<YOUR-APP-KEY-HERE>",
         analytics: true,
-        crashes: true
+        crashes: true,
+        distribute: true,
     }
 
     let appCenter = new AppCenter();

--- a/demo/app/main-page.xml
+++ b/demo/app/main-page.xml
@@ -10,6 +10,8 @@
     <Label text="{{ analyticsIsEnabled }}" class="t-20 text-center c-black" textWrap="true"/>
     <Label text="Crashes Status" class="t-20 text-center c-black" textWrap="true"/>
     <Label text="{{ crashesIsEnabled }}" class="t-20 text-center c-black" textWrap="true"/>
+    <Label text="Distribute Status" class="t-20 text-center c-black" textWrap="true"/>
+    <Label text="{{ distributeIsEnabled }}" class="t-20 text-center c-black" textWrap="true"/>
     <Button text="Crashes Test" tap="crashesTap"></Button>
   </StackLayout>
 </Page>

--- a/demo/app/main-view-model.ts
+++ b/demo/app/main-view-model.ts
@@ -1,15 +1,17 @@
 import { Observable } from 'tns-core-modules/data/observable';
-import { AppCenter, AppCenterSettings, AppCenterAnalytics, AppCenterCrashes } from 'nativescript-microsoft-appcenter';
+import { AppCenter, AppCenterSettings, AppCenterAnalytics, AppCenterCrashes, AppCenterDistribute } from 'nativescript-microsoft-appcenter';
 
 export class HelloWorldModel extends Observable {
   public appCenterInstallId: string;
   public appCenterIsEnabled: string;
   public analyticsIsEnabled: string;
   public crashesIsEnabled: string;
+  public distributeIsEnabled: string;
 
   appCenter = new AppCenter();
   analytics = new AppCenterAnalytics();
-  crashes = new AppCenterCrashes()
+  crashes = new AppCenterCrashes();
+  distribute = new AppCenterDistribute();
 
   constructor() {
     super();
@@ -21,5 +23,6 @@ export class HelloWorldModel extends Observable {
     this.analytics.trackEvent("main-view-model starts");
 
     this.crashesIsEnabled = this.crashes.isEnabled() ? "Enabled" : "Disabled";
+    this.distributeIsEnabled = this.distribute.isEnabled() ? "Enabled" : "Disabled";
   }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,6 +4,7 @@ export interface AppCenterSettings {
     appSecret?: string;
     analytics?: boolean;
     crashes?: boolean;
+    distribute?: boolean;
 }
 export interface TrackProperties {
     key: string;
@@ -28,4 +29,9 @@ export declare class AppCenterCrashes {
     isEnabled(): boolean;
     hasCrashedInLastSession(): boolean;
     generateTestCrash(): void;
+}
+export declare class AppCenterDistribute {
+    disable(): void;
+    enable(): void;
+    isEnabled(): boolean;
 }

--- a/src/microsoft-appcenter.android.ts
+++ b/src/microsoft-appcenter.android.ts
@@ -1,5 +1,4 @@
 import { AppCenterSettings, TrackProperties } from './microsoft-appcenter.common';
-import * as app from "tns-core-modules/application";
 
 declare var com: any;
 
@@ -19,7 +18,7 @@ export class AppCenter {
             services.push(com.microsoft.appcenter.distribute.Distribute.class);
         }
 
-        com.microsoft.appcenter.AppCenter.start(app.android.context, settings.appSecret, services);        
+        com.microsoft.appcenter.AppCenter.start(com.tns.NativeScriptApplication.getInstance(), settings.appSecret, services);
     }
 
     public startWithAppDelegate(settings: AppCenterSettings): void {

--- a/src/microsoft-appcenter.android.ts
+++ b/src/microsoft-appcenter.android.ts
@@ -15,6 +15,10 @@ export class AppCenter {
             services.push(com.microsoft.appcenter.crashes.Crashes.class);
         }
 
+        if (settings.distribute) {
+            services.push(com.microsoft.appcenter.distribute.Distribute.class);
+        }
+
         com.microsoft.appcenter.AppCenter.start(app.android.context, settings.appSecret, services);        
     }
 
@@ -78,5 +82,19 @@ export class AppCenterCrashes {
 
     public generateTestCrash(): void {
         com.microsoft.appcenter.crashes.Crashes.generateTestCrash();
+    }
+}
+
+export class AppCenterDistribute {
+    public disable(): void {
+        com.microsoft.appcenter.distribute.Distribute.setEnabled(false);
+    }
+
+    public enable(): void {
+        com.microsoft.appcenter.distribute.Distribute.setEnabled(true);
+    }
+
+    public isEnabled(): boolean {
+        return com.microsoft.appcenter.distribute.Distribute.isEnabled().get();
     }
 }

--- a/src/microsoft-appcenter.common.ts
+++ b/src/microsoft-appcenter.common.ts
@@ -5,6 +5,7 @@ export interface AppCenterSettings {
   appSecret?: string;
   analytics?: boolean;
   crashes?: boolean;
+  distribute?: boolean;
 }
 
 export interface TrackProperties {

--- a/src/microsoft-appcenter.ios.ts
+++ b/src/microsoft-appcenter.ios.ts
@@ -4,6 +4,7 @@ import * as application from "tns-core-modules/application";
 declare const MSAppCenter: any;
 declare const MSAnalytics: any;
 declare const MSCrashes: any;
+declare const MSDistribute: any;
 
 export class AppCenter {    
     public start(settings: AppCenterSettings): void {
@@ -15,6 +16,10 @@ export class AppCenter {
 
         if (settings.crashes) {
             services.addObject(MSCrashes);
+        }
+
+        if (settings.distribute) {
+            services.addObject(MSDistribute);
         }
 
         MSAppCenter.startWithServices(settings.appSecret, services);
@@ -89,6 +94,21 @@ export class AppCenterCrashes {
     }
 }
 
+export class AppCenterDistribute {
+
+    public disable(): void {
+        MSDistribute.setEnabled(false);
+    }
+
+    public enable(): void {
+        MSDistribute.setEnabled(true);
+    }
+
+    public isEnabled(): boolean {
+        return MSDistribute.isEnabled();
+    }
+}
+
 export class AppCenterDelegate extends UIResponder implements UIApplicationDelegate {
     private static settings: AppCenterSettings;
     public static ObjCProtocols = [UIApplicationDelegate];
@@ -106,6 +126,10 @@ export class AppCenterDelegate extends UIResponder implements UIApplicationDeleg
 
         if (AppCenterDelegate.settings.crashes) {
             services.addObject(MSCrashes);
+        }
+
+        if (AppCenterDelegate.settings.distribute) {
+            services.addObject(MSDistribute);
         }
 
         MSAppCenter.startWithServices(AppCenterDelegate.settings.appSecret, services);

--- a/src/platforms/android/include.gradle
+++ b/src/platforms/android/include.gradle
@@ -5,7 +5,8 @@ android {
 }
 
 dependencies {
-    def appCenterSdkVersion = '1.8.0'
+    def appCenterSdkVersion = '2.2.0'
     compile "com.microsoft.appcenter:appcenter-analytics:${appCenterSdkVersion}"
     compile "com.microsoft.appcenter:appcenter-crashes:${appCenterSdkVersion}"
+    compile "com.microsoft.appcenter:appcenter-distribute:${appCenterSdkVersion}"
 }

--- a/src/platforms/ios/Podfile
+++ b/src/platforms/ios/Podfile
@@ -1,1 +1,2 @@
 pod 'AppCenter'
+pod 'AppCenter/Distribute'


### PR DESCRIPTION
- Added support for appcenter distribute (https://docs.microsoft.com/en-us/appcenter/sdk/distribute/android)
- Fix: app.android.context seems to be null under some circumstances. Using com.tns.NativeScriptApplication.getInstance() instead seems to solve that for other plugins as well: https://github.com/EddyVerbruggen/nativescript-plugin-firebase/commit/f25cc8218fa6224d3cac40a16c62b38866cef1bc